### PR TITLE
Use UInt32 for Register Pointers

### DIFF
--- a/Sources/SwiftyGPIO.swift
+++ b/Sources/SwiftyGPIO.swift
@@ -280,20 +280,20 @@ extension GPIO: CustomStringConvertible {
 
 public final class RaspberryGPIO: GPIO {
 
-    var setGetId: UInt = 0
+    var setGetId: UInt32 = 0
     var baseAddr: Int = 0
     var inited = false
 
     let BCM2708_PERI_BASE: Int
     let GPIO_BASE: Int
 
-    var gpioBasePointer: UnsafeMutablePointer<UInt>!
-    var gpioGetPointer: UnsafeMutablePointer<UInt>!
-    var gpioSetPointer: UnsafeMutablePointer<UInt>!
-    var gpioClearPointer: UnsafeMutablePointer<UInt>!
+    var gpioBasePointer: UnsafeMutablePointer<UInt32>!
+    var gpioGetPointer: UnsafeMutablePointer<UInt32>!
+    var gpioSetPointer: UnsafeMutablePointer<UInt32>!
+    var gpioClearPointer: UnsafeMutablePointer<UInt32>!
 
     public init(name: String, id: Int, baseAddr: Int) {
-        self.setGetId = UInt(1<<id)
+        self.setGetId = UInt32(1<<id)
         self.BCM2708_PERI_BASE = baseAddr
         self.GPIO_BASE = BCM2708_PERI_BASE + 0x200000 /* GPIO controller */
         super.init(name:name, id:id)
@@ -368,7 +368,7 @@ public final class RaspberryGPIO: GPIO {
             perror("mmap error")
             abort()
         }
-        gpioBasePointer = gpio_map.assumingMemoryBound(to: UInt.self)
+        gpioBasePointer = gpio_map.assumingMemoryBound(to: UInt32.self)
 
         gpioGetPointer = gpioBasePointer.advanced(by: 13)   // GPLEV0
         gpioSetPointer = gpioBasePointer.advanced(by: 7)    // GPSET0
@@ -521,7 +521,7 @@ public enum GPIOEdge: String {
     case BOTH="both"
 }
 
-public enum GPIOPull: UInt {
+public enum GPIOPull: UInt32 {
     case neither = 0
     case down    = 1
     case up      = 2


### PR DESCRIPTION
### What's in this pull request?

The GPIO base pointers used for the Raspberry Pi boards are UnsafeMutablePointer<UInt>, assuming that UInt == UInt32.

When compiling SwiftyGPIO for arm64, this makes the stride calculations wrong, as it will jump ’n * 8’ bytes instead of ’n * 4’ bytes.

This change converts the base pointers to be using UnsafeMutablePointer<UInt32> instead, and then deals with all the fallout from that change.